### PR TITLE
feat: add SMS segmentation and inbound auto-replies

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,9 +2,19 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from backend.devices.serial_port import probe_modems
+from backend.sms.receiver import start_receiver
 from backend.sms.sender import send_sms
+from backend.sms.store import INBOX
 
 app = FastAPI()
+RECEIVERS: list = []
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    for dev in probe_modems():
+        if dev.get("sim_ready"):
+            RECEIVERS.append(start_receiver(dev["port"]))
 
 
 @app.get("/healthz")
@@ -24,9 +34,14 @@ class Message(BaseModel):
 
 
 @app.post("/api/messages")
-def api_send(message: Message) -> dict[str, str]:
+def api_send(message: Message) -> dict[str, list[str]]:
     try:
-        ref = send_sms(message.msisdn, message.text, message.device_id)
+        refs = send_sms(message.msisdn, message.text, message.device_id)
     except Exception as exc:  # pragma: no cover - surface error
         raise HTTPException(status_code=500, detail=str(exc)) from exc
-    return {"ref": ref}
+    return {"refs": refs}
+
+
+@app.get("/api/inbox")
+def api_inbox() -> list[dict]:
+    return INBOX

--- a/backend/sms/pdu.py
+++ b/backend/sms/pdu.py
@@ -1,8 +1,9 @@
-"""Simple SMS PDU builder supporting GSM 7-bit and UCS-2."""
+"""SMS PDU helpers for encoding, segmentation and decoding."""
 
 from __future__ import annotations
 
-from typing import Tuple
+import random
+from typing import List, Tuple
 
 GSM_7BIT_BASIC = {chr(i) for i in range(32, 127)} | {"\n", "\r", "\f", "\b", "\t"}
 
@@ -20,49 +21,144 @@ def _encode_number(number: str) -> Tuple[str, str, int]:
     return toa, swapped, len(number)
 
 
-def _encode_gsm7(text: str) -> Tuple[str, int]:
+def _encode_gsm7(text: str, udh: bytes | None = None) -> Tuple[str, int]:
     data = bytearray()
     carry = 0
     carry_bits = 0
-    for ch in text:
-        val = ord(ch) & 0x7F
-        byte = ((val << carry_bits) & 0xFF) | carry
-        data.append(byte)
-        carry = val >> (8 - carry_bits)
+
+    def push(byte: int) -> None:
+        nonlocal carry, carry_bits
+        data.append(((byte << carry_bits) & 0xFF) | carry)
+        carry = byte >> (8 - carry_bits)
         carry_bits += 1
         if carry_bits == 8:
             data.append(carry)
             carry = 0
             carry_bits = 0
+
+    if udh:
+        for b in udh:
+            push(b)
+    for ch in text:
+        push(ord(ch) & 0x7F)
     if carry_bits:
         data.append(carry)
-    return data.hex().upper(), len(text)
+    if udh:
+        udl = len(data)
+    else:
+        udl = len(text)
+    return data.hex().upper(), udl
 
 
-def _encode_ucs2(text: str) -> Tuple[str, int]:
+def _encode_ucs2(text: str, udh: bytes | None = None) -> Tuple[str, int]:
     data = text.encode("utf-16-be")
+    if udh:
+        data = udh + data
     return data.hex().upper(), len(data)
 
 
-def build_pdu(msisdn: str, text: str) -> str:
-    toa, number, length = _encode_number(msisdn)
-    if all(ch in GSM_7BIT_BASIC for ch in text):
-        ud, udl = _encode_gsm7(text)
-        dcs = "00"
+def _segment_text(text: str, encoding: str) -> List[str]:
+    if encoding == "gsm7":
+        limit = 160
+        part = 153
     else:
-        ud, udl = _encode_ucs2(text)
-        dcs = "08"
-    first_octet = "01"
-    pdu = (
-        "00"  # SMSC
-        + first_octet
-        + "00"  # MR
-        + f"{length:02X}"
-        + toa
-        + number
-        + "00"  # PID
-        + dcs
-        + f"{udl:02X}"
-        + ud
-    )
-    return pdu
+        limit = 70
+        part = 67
+    if len(text) <= limit:
+        return [text]
+    return [text[i : i + part] for i in range(0, len(text), part)]
+
+
+def build_pdus(msisdn: str, text: str) -> list[dict[str, object]]:
+    """Build PDUs for the given text, handling segmentation."""
+    encoding = "gsm7" if all(ch in GSM_7BIT_BASIC for ch in text) else "ucs2"
+    segments = _segment_text(text, encoding)
+    ref = random.randint(0, 255) if len(segments) > 1 else None
+    toa, number, length = _encode_number(msisdn)
+    dcs = "00" if encoding == "gsm7" else "08"
+    pdus: list[dict[str, object]] = []
+    for idx, segment in enumerate(segments, start=1):
+        udh = (
+            bytes([5, 0, 3, ref or 0, len(segments), idx]) if ref is not None else None
+        )
+        if encoding == "gsm7":
+            ud, udl = _encode_gsm7(segment, udh)
+        else:
+            ud, udl = _encode_ucs2(segment, udh)
+        first_octet = "41" if udh else "01"
+        pdu = (
+            "00"
+            + first_octet
+            + "00"
+            + f"{length:02X}"
+            + toa
+            + number
+            + "00"
+            + dcs
+            + f"{udl:02X}"
+            + ud
+        )
+        pdus.append(
+            {"pdu": pdu, "seg_total": len(segments), "seg_index": idx, "text": segment}
+        )
+    return pdus
+
+
+def _decode_gsm7(data: bytes, udhl: int = 0) -> str:
+    bits = 0
+    carry = 0
+    septets: list[int] = []
+    for byte in data:
+        septets.append(((byte << bits) & 0x7F) | carry)
+        carry = byte >> (7 - bits)
+        bits += 1
+        if bits == 7:
+            septets.append(carry & 0x7F)
+            carry = 0
+            bits = 0
+    text = "".join(chr(s) for s in septets)
+    if udhl:
+        skip = ((udhl + 1) * 8 + 6) // 7
+        text = text[skip:]
+    return text.rstrip("\x00")
+
+
+def parse_pdu(pdu: str) -> Tuple[str, str]:
+    """Parse an inbound PDU returning (msisdn, text)."""
+    i = 0
+    smsc_len = int(pdu[i : i + 2], 16)
+    i += 2 + smsc_len * 2
+    first = int(pdu[i : i + 2], 16)
+    i += 2
+    addr_len = int(pdu[i : i + 2], 16)
+    i += 2
+    toa = pdu[i : i + 2]
+    i += 2
+    addr_field_len = addr_len + (addr_len % 2)
+    number = pdu[i : i + addr_field_len]
+    i += addr_field_len
+    msisdn = "".join(
+        number[j + 1] + number[j] for j in range(0, len(number), 2)
+    ).rstrip("F")
+    if toa == "91":
+        msisdn = "+" + msisdn
+    i += 2  # PID
+    dcs = pdu[i : i + 2]
+    i += 2
+    i += 14  # timestamp
+    i += 2  # UDL
+    ud_bytes = bytes.fromhex(pdu[i:])
+    udhi = bool(first & 0x40)
+    if dcs == "00":
+        if udhi:
+            udhl = ud_bytes[0]
+            text = _decode_gsm7(ud_bytes, udhl)
+        else:
+            text = _decode_gsm7(ud_bytes)
+    else:
+        if udhi:
+            udhl = ud_bytes[0]
+            text = ud_bytes[udhl + 1 :].decode("utf-16-be")
+        else:
+            text = ud_bytes.decode("utf-16-be")
+    return msisdn, text

--- a/backend/sms/receiver.py
+++ b/backend/sms/receiver.py
@@ -1,0 +1,63 @@
+"""Inbound SMS receiving and simple auto-reply rules."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+import serial
+
+from backend.sms.pdu import parse_pdu
+from backend.sms.sender import send_sms
+from backend.sms.store import CONTACTS, INBOX
+
+INFO_TEMPLATE = "Thanks for your message."
+
+
+def _handle_inbound(
+    msisdn: str, text: str, device_id: str, port: serial.Serial
+) -> None:
+    INBOX.append({"msisdn": msisdn, "text": text, "device_id": device_id})
+    keyword = text.strip().upper()
+    if keyword == "STOP":
+        CONTACTS.setdefault(msisdn, {})["opt_out"] = True
+    elif keyword == "INFO":
+        if not CONTACTS.get(msisdn, {}).get("opt_out"):
+            try:
+                send_sms(msisdn, INFO_TEMPLATE, device_id, port=port)
+            except Exception as exc:  # pragma: no cover - hardware dependent
+                logging.warning("auto-reply failed: %s", exc)
+
+
+def _reader(device_id: str, baud: int = 115200) -> None:
+    while True:
+        try:
+            with serial.Serial(device_id, baudrate=baud, timeout=5) as port:
+                port.write(b"AT+CMGF=0\r")
+                port.readline()
+                port.write(b"AT+CNMI=2,2,0,0,0\r")
+                port.readline()
+                while True:
+                    line = port.readline().decode(errors="ignore").strip()
+                    if line.startswith("+CMT:"):
+                        pdu_line = port.readline().decode(errors="ignore").strip()
+                        try:
+                            msisdn, text = parse_pdu(pdu_line)
+                            _handle_inbound(msisdn, text, device_id, port)
+                        except Exception as exc:  # pragma: no cover - best effort
+                            logging.warning("parse error: %s", exc)
+                    elif not line:
+                        # Poll fallback
+                        port.write(b"AT+CMGL=4\r")
+                        time.sleep(1)
+                        break
+        except Exception as exc:  # pragma: no cover - hardware dependent
+            logging.warning("receiver error on %s: %s", device_id, exc)
+            time.sleep(2)
+
+
+def start_receiver(device_id: str, baud: int = 115200) -> threading.Thread:
+    thread = threading.Thread(target=_reader, args=(device_id, baud), daemon=True)
+    thread.start()
+    return thread

--- a/backend/sms/sender.py
+++ b/backend/sms/sender.py
@@ -1,37 +1,67 @@
-"""SMS sending via AT commands."""
+"""SMS sending via AT commands with segmentation support."""
 
 from __future__ import annotations
 
 import logging
+from typing import List
 
 import serial
 
-from backend.sms.pdu import build_pdu
+from backend.sms.pdu import build_pdus
+from backend.sms.store import OUTBOX
 
 
-def send_sms(msisdn: str, text: str, device_id: str, baud: int = 115200) -> str:
-    """Send a single SMS via the given serial device.
+def send_sms(
+    msisdn: str,
+    text: str,
+    device_id: str,
+    baud: int = 115200,
+    port: serial.Serial | None = None,
+) -> List[str]:
+    """Send an SMS, handling long-message segmentation.
 
-    Returns the message reference reported by the modem.
+    Returns list of message references reported by the modem.
     """
-    pdu = build_pdu(msisdn, text)
-    tpdu_length = (len(pdu) // 2) - 1  # exclude SMSC length octet
-    logging.info("sending PDU %s", pdu)
-    with serial.Serial(device_id, baudrate=baud, timeout=5) as port:
+
+    close_port = False
+    if port is None:
+        port = serial.Serial(device_id, baudrate=baud, timeout=5)
+        close_port = True
+    try:
+        pdus = build_pdus(msisdn, text)
+        refs: list[str] = []
         port.write(b"AT+CMGF=0\r")
         port.readline()
-        port.write(f"AT+CMGS={tpdu_length}\r".encode())
-        port.readline()
-        port.write(bytes.fromhex(pdu) + b"\x1A")
-        ref = ""
-        while True:
-            line = port.readline().decode(errors="ignore").strip()
-            if not line:
-                continue
-            if line.startswith("+CMGS:"):
-                ref = line.split(":")[1].strip()
-            if line in {"OK", "ERROR"} or line.startswith("+CMS ERROR"):
-                if line != "OK":
-                    raise RuntimeError(line)
-                break
-    return ref
+        for seg in pdus:
+            pdu = seg["pdu"]
+            tpdu_length = (len(pdu) // 2) - 1
+            logging.info("sending PDU %s", pdu)
+            port.write(f"AT+CMGS={tpdu_length}\r".encode())
+            port.readline()
+            port.write(bytes.fromhex(pdu) + b"\x1a")
+            ref = ""
+            while True:
+                line = port.readline().decode(errors="ignore").strip()
+                if not line:
+                    continue
+                if line.startswith("+CMGS:"):
+                    ref = line.split(":")[1].strip()
+                if line in {"OK", "ERROR"} or line.startswith("+CMS ERROR"):
+                    if line != "OK":
+                        raise RuntimeError(line)
+                    break
+            refs.append(ref)
+            OUTBOX.append(
+                {
+                    "msisdn": msisdn,
+                    "text": seg["text"],
+                    "device_id": device_id,
+                    "seg_total": seg["seg_total"],
+                    "seg_index": seg["seg_index"],
+                    "ref": ref,
+                }
+            )
+        return refs
+    finally:
+        if close_port:
+            port.close()

--- a/backend/sms/store.py
+++ b/backend/sms/store.py
@@ -1,0 +1,7 @@
+"""In-memory storage for SMS messages and contacts."""
+
+from __future__ import annotations
+
+INBOX: list[dict] = []
+OUTBOX: list[dict] = []
+CONTACTS: dict[str, dict] = {}


### PR DESCRIPTION
## Summary
- segment long SMS messages and build UDH for each part
- store outbound segments and process inbound messages with simple rules
- expose inbox endpoint and auto-reply to INFO keyword

## Testing
- `ruff check .`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fd652eae88333b184e4622ee17ad3