### PR TITLE
Add campaign CSV watcher and phone number validation

### DIFF
--- a/backend/campaign_watcher.py
+++ b/backend/campaign_watcher.py
@@ -1,0 +1,96 @@
+"""Watch a folder for CSV campaign files and schedule sending."""
+
+from __future__ import annotations
+
+import csv
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from backend.db import SessionLocal
+from backend.models import Campaign, Contact, List, ListMember
+from backend.utils import normalize_msisdn
+
+WATCH_DIR = Path(__file__).resolve().parent.parent / "inbox" / "campaigns"
+
+
+class _CampaignHandler(FileSystemEventHandler):
+    def __init__(self, scheduler):
+        super().__init__()
+        self.scheduler = scheduler
+
+    def on_created(self, event) -> None:  # pragma: no cover - filesystem events
+        if event.is_directory or not event.src_path.endswith(".csv"):
+            return
+        path = Path(event.src_path)
+        _process_csv(path, self.scheduler)
+
+
+def _process_csv(path: Path, scheduler) -> None:
+    from backend.main import send_campaign  # local import to avoid circular
+
+    db = SessionLocal()
+    try:
+        with path.open(newline="") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        if not rows:
+            return
+        name = path.stem
+        template = rows[0].get("text", "")
+        contact_ids: list[int] = []
+        list_obj = List(name=name)
+        db.add(list_obj)
+        db.commit()
+        db.refresh(list_obj)
+        for row in rows:
+            msisdn_raw = row.get("msisdn", "")
+            try:
+                msisdn = normalize_msisdn(msisdn_raw)
+            except ValueError as exc:
+                logging.warning("invalid number %s in %s: %s", msisdn_raw, path, exc)
+                continue
+            contact = db.query(Contact).filter(Contact.msisdn == msisdn).first()
+            if not contact:
+                contact = Contact(msisdn=msisdn)
+                db.add(contact)
+                db.commit()
+                db.refresh(contact)
+            db.add(ListMember(list_id=list_obj.id, contact_id=contact.id))
+            contact_ids.append(contact.id)
+        db.commit()
+        campaign = Campaign(
+            name=name,
+            template=template,
+            list_id=list_obj.id,
+            start_time=datetime.utcnow(),
+            rate_limit=1,
+        )
+        db.add(campaign)
+        db.commit()
+        db.refresh(campaign)
+        scheduler.add_job(
+            send_campaign, "date", run_date=campaign.start_time, args=[campaign.id]
+        )
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.error("failed to process %s: %s", path, exc)
+    finally:
+        db.close()
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def start_campaign_watcher(scheduler) -> Observer:
+    os.makedirs(WATCH_DIR, exist_ok=True)
+    handler = _CampaignHandler(scheduler)
+    observer = Observer()
+    observer.schedule(handler, str(WATCH_DIR), recursive=False)
+    observer.daemon = True
+    observer.start()
+    return observer

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,0 +1,39 @@
+"""Utility helpers for MSISDN normalization and webhooks."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import phonenumbers
+import requests
+from phonenumbers import NumberParseException, PhoneNumberFormat
+
+DEFAULT_COUNTRY = os.getenv("DEFAULT_COUNTRY", "US")
+STATUS_WEBHOOK_URL = os.getenv("STATUS_WEBHOOK_URL")
+
+
+def normalize_msisdn(msisdn: str) -> str:
+    """Normalize a phone number to E.164 format using default country.
+
+    Raises ValueError if the number is invalid.
+    """
+    try:
+        num = phonenumbers.parse(msisdn, DEFAULT_COUNTRY)
+    except NumberParseException as exc:  # pragma: no cover - library errors
+        raise ValueError(str(exc)) from exc
+    if not phonenumbers.is_valid_number(num):
+        raise ValueError("invalid msisdn")
+    return phonenumbers.format_number(num, PhoneNumberFormat.E164)
+
+
+def notify_status(payload: dict) -> None:
+    """POST a status update to the configured webhook if set."""
+    url: Optional[str] = STATUS_WEBHOOK_URL
+    if not url:
+        return
+    try:
+        requests.post(url, json=payload, timeout=5)
+    except Exception as exc:  # pragma: no cover - network errors
+        logging.warning("webhook post failed: %s", exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "apscheduler",
     "python-jose[cryptography]",
     "passlib[bcrypt]",
+    "phonenumbers",
+    "requests",
+    "watchdog",
 ]
 
 [tool.black]


### PR DESCRIPTION
## Summary
- add utility helpers for E.164 normalization and webhook notifications
- watch inbox/campaigns for CSV files and auto-create campaigns
- validate MSISDNs by country and send status webhooks for message updates

## Testing
- `pre-commit run --files backend/utils.py backend/campaign_watcher.py backend/main.py backend/sms/receiver.py pyproject.toml`
- `python - <<'PY'\nfrom backend.utils import normalize_msisdn\nprint(normalize_msisdn('2025550125'))\nPY`
- `python - <<'PY'\nfrom apscheduler.schedulers.background import BackgroundScheduler\nfrom backend.campaign_watcher import start_campaign_watcher, WATCH_DIR\nimport os\n\nsched = BackgroundScheduler()\observer = start_campaign_watcher(sched)\nprint('watching', os.path.isdir(WATCH_DIR))\nobserver.stop()\nobserver.join()\nPY`

------
https://chatgpt.com/codex/tasks/task_e_689fdec6f01883338d6cbc08efb67f21