### PR TITLE
Add static project website

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Monorepo for experimental SMS gateway with FastAPI backend and React UI.
 - Vite + React + TypeScript
 - From `ui` directory run: `npm run dev`
 
+## Website
+
+A static project website is available in the `website/` directory. Open `website/index.html` in a browser for an overview and usage instructions.
+
 ## Development
 
 Install pre-commit hooks:

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>MuxoSMS</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>MuxoSMS</h1>
+    <nav>
+      <a href="#backend">Backend</a>
+      <a href="#ui">UI</a>
+      <a href="#development">Development</a>
+      <a href="#backups">Backups</a>
+    </nav>
+  </header>
+  <main>
+    <section id="backend">
+      <h2>Backend</h2>
+      <p>Python 3.11 + FastAPI</p>
+      <pre><code>uvicorn backend.main:app</code></pre>
+    </section>
+    <section id="ui">
+      <h2>UI</h2>
+      <p>Vite + React + TypeScript</p>
+      <pre><code>npm run dev</code></pre>
+    </section>
+    <section id="development">
+      <h2>Development</h2>
+      <p>Install pre-commit hooks:</p>
+      <pre><code>pre-commit install</code></pre>
+      <p>Run lint checks:</p>
+      <pre><code>pre-commit run --files &lt;files&gt;
+npm run lint --prefix ui</code></pre>
+    </section>
+    <section id="backups">
+      <h2>Backups</h2>
+      <p>
+        Nightly backups of the SQLite database are stored in the
+        <code>backups/</code> directory with a timestamped filename.
+      </p>
+      <ol>
+        <li>Stop the application.</li>
+        <li>
+          Replace <code>muxo.db</code> with the desired backup file:
+          <pre><code>cp backups/muxo-&lt;timestamp&gt;.db muxo.db</code></pre>
+        </li>
+        <li>Start the application again.</li>
+      </ol>
+      <p>
+        Old messages older than 90 days and audit records older than 365 days
+        are purged during the nightly job.
+      </p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> MuxoSMS</p>
+    <button id="back-to-top">Back to top</button>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/website/script.js
+++ b/website/script.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const year = document.getElementById('year');
+  if (year) {
+    year.textContent = new Date().getFullYear().toString();
+  }
+
+  const btn = document.getElementById('back-to-top');
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 200) {
+      btn.style.display = 'block';
+    } else {
+      btn.style.display = 'none';
+    }
+  });
+
+  btn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+});

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,58 @@
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+}
+
+header {
+  background: #333;
+  color: #fff;
+  padding: 1rem;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+main {
+  padding: 1rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+pre {
+  background: #f4f4f4;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+code {
+  font-family: monospace;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #f4f4f4;
+  position: relative;
+}
+
+#back-to-top {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  display: none;
+  padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
## Summary
- add static `website` with HTML, CSS, and JS showcasing project sections
- include back-to-top button and dynamic year
- document website location in README

## Testing
- `pre-commit run --files README.md website/index.html website/styles.css website/script.js`
- `npm run lint --prefix ui`


------
https://chatgpt.com/codex/tasks/task_e_689fe08377888333ba73cc11a4ebc593